### PR TITLE
Fix node and apt

### DIFF
--- a/conf/fakenode-deps.control
+++ b/conf/fakenode-deps.control
@@ -1,0 +1,7 @@
+Section: misc
+Priority: optional
+Package: nodejs
+Version: 8.0.0
+Depends:
+Architecture: all
+Description: Fake package for nodejs

--- a/scripts/install
+++ b/scripts/install
@@ -83,11 +83,12 @@ ynh_app_setting_set $app port $port
 # INSTALL POSTGRES
 #==============================================
 
-ynh_install_app_dependencies postgresql redis-server rabbitmq-server apt-transport-https
+# ynh_install_app_dependencies postgresql redis-server rabbitmq-server apt-transport-https
 #sudo apt-get install -y postgresql redis-server rabbitmq-server apt-transport-https
 
 #Next for new test 5
-#ynh_install_app_dependencies postgresql redis-server rabbitmq-server apt-transport-https libcurl3 libxml2 supervisor fonts-dejavu fonts-liberation ttf-mscorefonts-installer fonts-crosextra-carlito fonts-takao-gothic fonts-opensymbol
+ynh_install_app_dependencies postgresql redis-server apt-transport-https libcurl3 libxml2 supervisor fonts-dejavu fonts-liberation ttf-mscorefonts-installer fonts-crosextra-carlito fonts-takao-gothic fonts-opensymbol libasound2 libboost-regex-dev libcairo2 libgconf2-4 libgtkglext1 libxtst6 postgresql-client pwgen xvfb
+# ynh_install_app_dependencies postgresql redis-server rabbitmq-server apt-transport-https libcurl3 libxml2 supervisor fonts-dejavu fonts-liberation ttf-mscorefonts-installer fonts-crosextra-carlito fonts-takao-gothic fonts-opensymbol
 
 #=================================================
 # INSTALL NODEJS
@@ -95,16 +96,16 @@ ynh_install_app_dependencies postgresql redis-server rabbitmq-server apt-transpo
 # Use Helper instead of package from the repo
 
 #Next for new test 5
-#ynh_install_nodejs 8.12.0
-curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
+ynh_install_nodejs 8.12.0
+# curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 
 #===============================================
 # ADD ONLYOFFCE REPOSITORY
 #===============================================
 
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
-echo "deb http://download.onlyoffice.com/repo/debian squeeze main" | sudo tee /etc/apt/sources.list.d/onlyoffice.list
-ynh_package_update
+# apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
+# echo "deb http://download.onlyoffice.com/repo/debian squeeze main" | sudo tee /etc/apt/sources.list.d/onlyoffice.list
+# ynh_package_update
 
 #==============================================
 # CREATE DB
@@ -124,13 +125,15 @@ echo onlyoffice-documentserver onlyoffice/ds-port select 9980 | sudo debconf-set
 # INSTALL ONLYOFFICE
 #==============================================
 
-ynh_package_install onlyoffice-documentserver
+# ynh_package_install onlyoffice-documentserver
 
 #sudo apt-get install -y onlyoffice-documentserver
 
 #apt install onlyoffice-documentserver
-#wget --no-verbose https://github.com/ONLYOFFICE/DocumentServer/releases/download/ONLYOFFICE-DocumentServer-5.2.3/onlyoffice-documentserver_amd64.deb
-#dpkg --install onlyoffice-documentserver_amd64.deb
+ynh_package_install_from_equivs ../conf/fakenode-deps.control
+wget --no-verbose https://github.com/ONLYOFFICE/DocumentServer/releases/download/ONLYOFFICE-DocumentServer-5.2.3/onlyoffice-documentserver_amd64.deb
+dpkg --install onlyoffice-documentserver_amd64.deb
+# ynh_apt remove nodejs
 
 #=================================================
 # NGINX CONFIGURATION
@@ -188,4 +191,3 @@ ynh_app_setting_set $app unprotected_uris "/"
 
 # Reload services
 systemctl restart nginx
-


### PR DESCRIPTION
Quick fix
I removed rabbitmq-server because it doesn't work on my VM and breaks the install.

During my last test, onlyoffice-documentserver was complaining about postgresql-client which was missing, but it's part of the dependencies.